### PR TITLE
Site Checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,10 @@ echo -e "# Description: Run an encrypted check\necho 'Encrypted script test'" > 
 gpg -c --no-symkey-cache --armour -o etc/checks/encrypted_example.sh.gpg /tmp/encrypted_example.sh.source
 ```
 
+### Site Checks
+
+A configurable "site" directory can be specified in config.yaml which provides an extra source of check scripts.
+
 ## Statuses
 
 `Statuses` provide information about the system to a user describing the state of the system. 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ An example of putting the files in place and installing dependencies (as root):
 git clone https://github.com/openflighthpc/flight-report /tmp/flight-report
 
 # Copy files into place
-cp -r /tmp/flight-report/opt $flight_ROOT/
-cp -r /tmp/flight-report/libexec $flight_ROOT/
+cp -ru /tmp/flight-report/opt $flight_ROOT/
+cp -ru /tmp/flight-report/libexec $flight_ROOT/
 
 # Optional: Configure CLI tool (otherwise will use default settings)
 ## Open and edit the file to change defaults

--- a/README.md
+++ b/README.md
@@ -93,7 +93,13 @@ flight_TIP_root="false"
 
 ## Updating
 
-To update the CLI tool simply clone the repository and copy the files into place again, overwriting the existing ones. 
+To update the CLI tool simply clone the repository and copy the files into place again, overwriting the existing ones.
+
+Can only overwrite files that have changed with:
+```bash
+cp -r /tmp/flight-report/opt $flight_ROOT/
+cp -r /tmp/flight-report/libexec $flight_ROOT/
+```
 
 # File Structure
 
@@ -111,6 +117,8 @@ Each check script must:
 - Be created in `etc/checks/` and end with `.sh`
 - Contain a line starting `# Description:` followed by a brief description of what the script does
 - Be a BASH script
+
+For a user to have access to encrypted checks and have their checks automatically saved to a report file they will need to be in the privileged users list in the config file.
 
 ### Encrypted Checks
 
@@ -132,6 +140,8 @@ gpg -c --no-symkey-cache --armour -o etc/checks/encrypted_example.sh.gpg /tmp/en
 ### Site Checks
 
 A configurable "site" directory can be specified in config.yaml which provides an extra source of check scripts.
+
+These scripts also have to stick to the "musts" specified at the beginning of this section (except the location must be in the location specified by `sitechecksdir` in `config.yaml`)
 
 ## Statuses
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ Each check script must:
 
 For a user to have access to encrypted checks and have their checks automatically saved to a report file they will need to be in the privileged users list in the config file.
 
+### [Optional] Check Questions
+
+A check can ask some questions to a user too which will be exported as environment variables to the shell. A questions file must: 
+- Be in the same directory as the script
+- Be named the same but end with `.sh.questions`
+
+The formatting of this file is the same as the `questions.yaml` file for Issues.
+
 ### Encrypted Checks
 
 Encrypted checks are useful for allowing only certain users entrusted with a decryption password to be able to execute the tests (without exposing the content of the scripts to unauthorised users). 

--- a/opt/report/bin/checks
+++ b/opt/report/bin/checks
@@ -8,14 +8,15 @@ require 'tempfile'
 
 require_relative "../lib/config"
 require_relative "../lib/checks"
+require_relative "../lib/utils"
 
-prompt = TTY::Prompt.new(active_color: :blue, interrupt: :exit)
+@prompt = TTY::Prompt.new(active_color: :blue, interrupt: :exit)
 
 password = nil
 if check_privileged
-  privileged = prompt.yes?("Do you want to run administrative checks?")
+  privileged = @prompt.yes?("Do you want to run administrative checks?")
   if privileged
-    password = prompt.mask("Enter passphrase for administrative checks:")
+    password = @prompt.mask("Enter passphrase for administrative checks:")
   end
 end
 
@@ -26,13 +27,25 @@ if checks.empty?
   exit
 end
 
-selected_checks = prompt.multi_select("Select checks to run:", per_page: 10) do |menu| 
+selected_checks = @prompt.multi_select("Select checks to run:", per_page: 10) do |menu| 
   checks.each.map {|check| menu.choice "#{check['name']}: #{check['description']}", check}
 end
 
 if selected_checks.empty?
   puts "No checks selected. Exiting."
   exit
+end
+
+# Get additional info per script
+selected_checks.each do |check|
+  if check['questions']
+    puts
+    puts "#{check['name']} - Additional information needed before running check"
+    check['vars'] = {}
+    check['questions'].each do |question|
+      check['vars'][question['var']] = ask_question(question)
+    end
+  end
 end
 
 #Run selected scripts and log
@@ -43,6 +56,11 @@ File.open(TMP_RESULTS, 'a+') do |file|
   selected_checks.each do |check|
     spinner = TTY::Spinner.new("[:spinner] Running #{check['name']} ...", format: :bouncing_ball)
     spinner.auto_spin
+    if check.key?('vars')
+      check['vars'].each do |key, val|
+        ENV[key] = val
+      end
+    end
     out = run_check(check)
     spinner.success("(Done)")
 

--- a/opt/report/bin/checks
+++ b/opt/report/bin/checks
@@ -57,11 +57,11 @@ end
 puts 
 TMP_RESULTS.close
 puts File.read(TMP_RESULTS)
-File.unlink(TMP_RESULTS.path)
 
 if check_privileged
   TIMESTAMP = Time.now.strftime("%Y-%m-%d_%H-%M")
   RESULTS_FILE = "#{Config.checkresultsdir}/status-report-#{TIMESTAMP}.txt"
-  File.write(RESULTS_FILE, check_output)
+  FileUtils.cp(TMP_RESULTS, RESULTS_FILE)
   puts "All selected checks have been executed. Results located in #{RESULTS_FILE}"
 end
+File.unlink(TMP_RESULTS.path)

--- a/opt/report/bin/checks
+++ b/opt/report/bin/checks
@@ -55,9 +55,10 @@ File.open(TMP_RESULTS, 'a+') do |file|
   file.puts "===== Execution finished at #{DateTime.now} =====\n\n"
 end
 
+puts 
 TMP_RESULTS.close
-File.read(TMP_RESULTS)
-TMP_RESULTS.unlink
+puts File.read(TMP_RESULTS)
+File.unlink(TMP_RESULTS.path)
 
 if check_privileged
   TIMESTAMP = Time.now.strftime("%Y-%m-%d_%H-%M")

--- a/opt/report/bin/checks
+++ b/opt/report/bin/checks
@@ -9,8 +9,7 @@ require 'tempfile'
 require_relative "../lib/config"
 require_relative "../lib/checks"
 
-TIMESTAMP = Time.now.strftime("%Y-%m-%d_%H-%M")
-RESULTS_FILE = "#{Config.checkresultsdir}/status-report-#{TIMESTAMP}.txt"
+TMP_RESULTS = Tempfile.create
 
 prompt = TTY::Prompt.new(active_color: :blue, interrupt: :exit)
 
@@ -39,7 +38,7 @@ if selected_checks.empty?
 end
 
 #Run selected scripts and log
-File.open(RESULTS_FILE, 'a+') do |file|
+File.open(TMP_RESULTS, 'a+') do |file|
   file.puts "===== Execution started at #{DateTime.now} ====="
 
   selected_checks.each do |check|
@@ -56,6 +55,13 @@ File.open(RESULTS_FILE, 'a+') do |file|
   file.puts "===== Execution finished at #{DateTime.now} =====\n\n"
 end
 
-puts File.read(RESULTS_FILE)
-puts "All selected checks have been executed. Results located in #{RESULTS_FILE}"
+TMP_RESULTS.close
+File.read(TMP_RESULTS)
+TMP_RESULTS.unlink
 
+if check_privileged
+  TIMESTAMP = Time.now.strftime("%Y-%m-%d_%H-%M")
+  RESULTS_FILE = "#{Config.checkresultsdir}/status-report-#{TIMESTAMP}.txt"
+  File.write(RESULTS_FILE, check_output)
+  puts "All selected checks have been executed. Results located in #{RESULTS_FILE}"
+end

--- a/opt/report/bin/checks
+++ b/opt/report/bin/checks
@@ -9,8 +9,6 @@ require 'tempfile'
 require_relative "../lib/config"
 require_relative "../lib/checks"
 
-TMP_RESULTS = Tempfile.create
-
 prompt = TTY::Prompt.new(active_color: :blue, interrupt: :exit)
 
 password = nil
@@ -38,6 +36,7 @@ if selected_checks.empty?
 end
 
 #Run selected scripts and log
+TMP_RESULTS = Tempfile.create
 File.open(TMP_RESULTS, 'a+') do |file|
   file.puts "===== Execution started at #{DateTime.now} ====="
 

--- a/opt/report/bin/report
+++ b/opt/report/bin/report
@@ -10,6 +10,7 @@ require_relative "../lib/config"
 require_relative "../lib/metrics"
 require_relative "../lib/report"
 require_relative "../lib/statistics"
+require_relative "../lib/utils"
 require_relative "../lib/xy"
 
 ARGS={}
@@ -41,7 +42,7 @@ statuses = {}
 report = Report.new
 
 # Create prompt
-prompt = TTY::Prompt.new(active_color: :blue, interrupt: :exit)
+@prompt = TTY::Prompt.new(active_color: :blue, interrupt: :exit)
 
 #
 # Stage 0: Log that someone has actually used this
@@ -56,7 +57,7 @@ end
 # Stage 1: Traffic Light Response Rating
 #
 
-happy = prompt.select("How would you rate your experience on your HPC environment today?", Config.traffic_lights.invert)
+happy = @prompt.select("How would you rate your experience on your HPC environment today?", Config.traffic_lights.invert)
 report.log['meta']['rating'] = happy
 
 ratingfile = "#{Config.ratingsdir}/#{report.ratingfilename}"
@@ -96,7 +97,7 @@ puts
 
 # Check with user
 if ! Config.always_report 
-  yes = prompt.yes?('Would you like to report an issue?', default: false)
+  yes = @prompt.yes?('Would you like to report an issue?', default: false)
   if ! yes
     puts "Thank you for time! Your response has been recorded"
     exit
@@ -113,7 +114,7 @@ issuedirs.each do |issue|
     issues[issue]['questions'] = YAML.load_file("#{issuedir}/questions.yaml")
   end
 end
-my_issue_dir = prompt.select("What issue would you like to report?") do |menu|
+my_issue_dir = @prompt.select("What issue would you like to report?") do |menu|
   issues.each.map {|dir,data| menu.choice "#{data['title']} (#{data['desc']})", dir}
 end
 
@@ -124,19 +125,7 @@ report.log['meta']['issue_id'] = my_issue_dir
 diag_vars = {}
 if my_issue.key?('questions') then
   my_issue['questions'].each do |question|
-    case question['type']
-    when "boolean"
-      answer = prompt.yes?(question['question'])
-    when "list"
-      answer = prompt.select(question['question'], question['options'])
-    when "text"
-      answer = prompt.ask(question['question'])
-    when "number"
-      answer = prompt.ask(question['question']) do |q|
-        q.validate(/^[0-9]*$/, "Answer must be a number or empty")
-      end
-    end
-    diag_vars[question['var']] = answer
+    diag_vars[question['var']] = ask_question(question)
   end
 end
 
@@ -220,7 +209,7 @@ spinner.success("Done!")
 
 # Show diagnostics to user
 if ! Config.hide_diagnostics
-  view = prompt.yes?("Would you like to view diagnostics?", default: false)
+  view = @prompt.yes?("Would you like to view diagnostics?", default: false)
   if view
     IO.popen("less", "w") { |f| f.puts report.outputs }
   end
@@ -236,7 +225,7 @@ if ! Config.hide_compare
   if prev_report_from_user && File.file?(prev_report_from_user)
     prev_report = Report.new(prev_report_from_user)
     prev_datetime = prev_report.log['meta']['issue_at']
-    compare = prompt.yes?("Would you like to compare diagnostics to your previous report at #{DateTime.parse(prev_datetime).strftime("%Y-%m-%d %H:%M:%S")}?", default: false)
+    compare = @prompt.yes?("Would you like to compare diagnostics to your previous report at #{DateTime.parse(prev_datetime).strftime("%Y-%m-%d %H:%M:%S")}?", default: false)
     if compare
       current = "# Current Diagnostics: #{DateTime.parse(report.log['meta']['issue_at']).strftime("%Y-%m-%d %H:%M:%S")}\n#{report.outputs}"
       previous = "# Previous Diagnostics: #{DateTime.parse(prev_datetime).strftime("%Y-%m-%d %H:%M:%S")}\n#{prev_report.outputs}"
@@ -257,8 +246,8 @@ else
   yesreport = true
 end
 until yesconfirm
-  yesreport = prompt.yes?("Would you like to send diagnostics report for '#{my_issue['title']}' to admin?", default: false)
-  yesconfirm = prompt.yes?("  Are you sure?", default: false)
+  yesreport = @prompt.yes?("Would you like to send diagnostics report for '#{my_issue['title']}' to admin?", default: false)
+  yesconfirm = @prompt.yes?("  Are you sure?", default: false)
 end
 
 if yesreport

--- a/opt/report/etc/config.yaml.example
+++ b/opt/report/etc/config.yaml.example
@@ -40,3 +40,8 @@ enable_emojis: true
 # the administrative check files
 privileged_check_users:
 - root
+
+# Specify additional directory for checks to be sourced from
+#
+# If this is set then checks will additionally be presented from here to users
+# sitechecksdir: /opt/site/scripts

--- a/opt/report/etc/config.yaml.example
+++ b/opt/report/etc/config.yaml.example
@@ -47,3 +47,9 @@ privileged_check_users:
 #
 # If this is set then checks will additionally be presented from here to users
 # sitechecksdir: /opt/site/scripts
+
+# Force the usage of the GPG CLI 
+#
+# In some situations on GPG 2.1+ the Ruby gem can have issues with silent failure.
+# This could be because of the gem or specifically GPG v2.2.20.
+force_gpg_cli: false

--- a/opt/report/etc/config.yaml.example
+++ b/opt/report/etc/config.yaml.example
@@ -38,6 +38,8 @@ enable_emojis: true
 # Any users in this list that run the check command will additionally be asked if they
 # want to run administrative checks and will be prompted for a password to decrypt 
 # the administrative check files
+#
+# Additionally, these users will have their check saved as a report
 privileged_check_users:
 - root
 

--- a/opt/report/lib/checks.rb
+++ b/opt/report/lib/checks.rb
@@ -62,6 +62,14 @@ def get_check_data(checkfile, encrypted: false, password: nil, source: "Alces")
     content = File.read(checkfile)
   end
 
+  # Questions
+  questionsfile = checkfile + '.questions'
+  if File.file?(questionsfile)
+    questions = YAML.load_file(questionsfile)
+  else
+    questions = nil
+  end
+
   description = content.each_line.find {|line| line =~ /^# Description: / }&.sub('# Description: ','')&.strip()
   if description.nil?
     description = "No description provided"
@@ -69,7 +77,7 @@ def get_check_data(checkfile, encrypted: false, password: nil, source: "Alces")
 
   name = "[#{source}] #{filename}"
 
-  out = {"name" => name, "description" => description, "content" => content}
+  out = {"name" => name, "description" => description, "content" => content, "questions" => questions}
   return out
 end
 

--- a/opt/report/lib/checks.rb
+++ b/opt/report/lib/checks.rb
@@ -44,7 +44,7 @@ def get_check_data(checkfile, encrypted: false, password: nil, source: "Alces")
   filename = File.basename(checkfile)
   if encrypted
     gpg_ver = `gpg --version |head -1 |sed 's/gpg (GnuPG) //g'`.to_f
-    if gpg_ver < 2.1
+    if gpg_ver < 2.1 || Config.force_gpg_cli
       content = `gpg -q -d --batch --passphrase "#{password}" --armor #{checkfile}`
       if content.empty?
         puts "Incorrect password or invalid (empty) script"

--- a/opt/report/lib/checks.rb
+++ b/opt/report/lib/checks.rb
@@ -26,6 +26,17 @@ def get_checks(include_privileged, password)
     @gpg.release
   end
 
+  # Get site checks
+  if Config.sitechecksdir
+    puts "Gathering site checks" 
+    site_check_files = Dir["#{Config.sitechecksdir}/*.sh"]
+
+    # Gather data for site checks
+    site_check_files.each do |checkfile|
+      checks.append(get_check_data(checkfile))
+    end
+  end
+
   # Returns a hash of all available checks
   return checks
 end

--- a/opt/report/lib/checks.rb
+++ b/opt/report/lib/checks.rb
@@ -21,7 +21,7 @@ def get_checks(include_privileged, password)
     # Prevent caching of correct password so it needs to be provided everytime checks are run
     @gpg.set_ctx_flag('no-symkey-cache', 1)
     privileged_check_files.each do |priv_file|
-      checks.append(get_check_data(priv_file, true, password))
+      checks.append(get_check_data(priv_file, encrypted: true, password: password))
     end
     @gpg.release
   end
@@ -32,7 +32,7 @@ def get_checks(include_privileged, password)
 
     # Gather data for site checks
     site_check_files.each do |checkfile|
-      checks.append(get_check_data(checkfile))
+      checks.append(get_check_data(checkfile, source: "Site"))
     end
   end
 
@@ -40,7 +40,7 @@ def get_checks(include_privileged, password)
   return checks
 end
 
-def get_check_data(checkfile, encrypted=false, password=nil)
+def get_check_data(checkfile, encrypted: false, password: nil, source: "Alces")
   filename = File.basename(checkfile)
   if encrypted
     gpg_ver = `gpg --version |head -1 |sed 's/gpg (GnuPG) //g'`.to_f
@@ -67,7 +67,9 @@ def get_check_data(checkfile, encrypted=false, password=nil)
     description = "No description provided"
   end
 
-  out = {"name" => filename, "description" => description, "content" => content}
+  name = "[#{source}] #{filename}"
+
+  out = {"name" => name, "description" => description, "content" => content}
   return out
 end
 

--- a/opt/report/lib/checks.rb
+++ b/opt/report/lib/checks.rb
@@ -28,7 +28,6 @@ def get_checks(include_privileged, password)
 
   # Get site checks
   if Config.sitechecksdir
-    puts "Gathering site checks" 
     site_check_files = Dir["#{Config.sitechecksdir}/*.sh"]
 
     # Gather data for site checks

--- a/opt/report/lib/checks.rb
+++ b/opt/report/lib/checks.rb
@@ -52,7 +52,7 @@ def get_check_data(checkfile, encrypted: false, password: nil, source: "Alces")
       end
     else
       begin
-        content = @gpg.decrypt(GPGME::Data.new(File.open(checkfile))).read
+        content = @gpg.decrypt(GPGME::Data.new(File.open(checkfile))).to_s
       rescue GPGME::Error::BadPassphrase, GPGME::Error::DecryptFailed
         puts "Failed to decrypt '#{filename}: Incorrect administrative password provided"
         exit 1

--- a/opt/report/lib/config.rb
+++ b/opt/report/lib/config.rb
@@ -87,6 +87,10 @@ class Config
       confval("sitechecksdir", nil)
     end
 
+    def force_gpg_cli
+      confval("force_gpg_cli", false)
+    end
+
     def traffic_lights
       if enable_emojis
         return {2 => "😀" , 1 => "😐", 0 => "🙁"}

--- a/opt/report/lib/config.rb
+++ b/opt/report/lib/config.rb
@@ -83,6 +83,10 @@ class Config
       confval("privileged_check_users", ['root'])
     end
 
+    def sitechecksdir
+      confval("sitechecksdir", nil)
+    end
+
     def traffic_lights
       if enable_emojis
         return {2 => "😀" , 1 => "😐", 0 => "🙁"}

--- a/opt/report/lib/utils.rb
+++ b/opt/report/lib/utils.rb
@@ -1,0 +1,16 @@
+def ask_question(question)
+  # question = {"question"=>"What do you want?", "type"=>"text/boolean/number/list", "options"=>["option1","option2"], "var"=>"VAR_NAME"}
+  case question['type']
+  when "boolean"
+    answer = @prompt.yes?(question['question'])
+  when "list"
+    answer = @prompt.select(question['question'], question['options'])
+  when "text"
+    answer = @prompt.ask(question['question'])
+  when "number"
+    answer = @prompt.ask(question['question']) do |q|
+      q.validate(/^[0-9]*$/, "Answer must be a number or empty")
+    end
+  end
+  return answer
+end


### PR DESCRIPTION
Adds an additional directory that checks can be loaded from, this allows for a "site" to add checks to the tool. 

Also, checks now support questions (in the same way that issues do) so extra data can be passed to them as environment variables.

Furthermore, encrypted checks have now been fixed and an option to force the usage of cli gpg instead of gem has been added as a workaround if environments have issue with it.